### PR TITLE
add websocket to README

### DIFF
--- a/examples/surgemq/README.md
+++ b/examples/surgemq/README.md
@@ -5,6 +5,7 @@ Standalone SurgeMQ server, creates listeners for plaintext MQTT, Websocket and S
 ## Build
 
 * `go get github.com/surgemq/surgemq`
+* `go get golang.org/x/net/websocket`
 * `cd $GOPATH/src/github.com/surgemq/surgemq/examples/surgemq/`
 * `go build`
 


### PR DESCRIPTION
```
$ cd $GOPATH/src/github.com/surgemq/surgemq/examples/surgemq/
$ go build
websocket.go:5:2: cannot find package "golang.org/x/net/websocket" in any of:
        /usr/local/opt/go/libexec/src/golang.org/x/net/websocket (from $GOROOT)
        /Users/ykomano/work/go/src/golang.org/x/net/websocket (from $GOPATH)
```

I guess we need to get websocket before `go build`.
If it is right, please merge this PR. :smile: 
